### PR TITLE
Host is no longer saved to leaderboard DB

### DIFF
--- a/server/game.js
+++ b/server/game.js
@@ -340,7 +340,8 @@ function calculateQuestionNumber(joinCode, gameId) {
  */
 async function sendToDB(joinCode, gameId) {
   const game = liveGames.get(joinCode);
-  const players = game.players;
+  let players = game.players;
+  players = players.filter(p => p.answerHistory.length > 0);
   await saveGameLeaderBoardRequest(gameId, players);
   await savePlayerContactDetailsRequest(playerContactDetailsStore);
 }


### PR DESCRIPTION
When game ends the player with 0 answers is filtered out and not saved to DB. Can't use isHost field because of hot potato